### PR TITLE
scan: Handle strings in a PrefixUUID

### DIFF
--- a/prefix.go
+++ b/prefix.go
@@ -73,27 +73,27 @@ func (pu PrefixUUID) MarshalJSON() ([]byte, error) {
 
 // Scan implements the Scanner interface. Note only the UUID gets scanned/set
 // here, we can't determine the prefix from the database. `value` should be
-// a [16]byte
+// a [16]byte or a string.
 func (pu *PrefixUUID) Scan(value interface{}) error {
 	if value == nil {
 		return errors.New("types: cannot scan null into a PrefixUUID")
 	}
-	bits, ok := value.([]byte)
-	if !ok {
-		return fmt.Errorf("types: can't scan value %v into a PrefixUUID", value)
-	}
 	var err error
-	if len(bits) >= 36 {
-		*pu, err = NewPrefixUUID(string(bits))
-	} else {
-		var u *uuid.UUID
-		u, err = uuid.Parse(bits)
-		pu.UUID = u
+	switch t := value.(type) {
+	case []byte:
+		if len(t) >= 36 {
+			*pu, err = NewPrefixUUID(string(t))
+		} else {
+			var u *uuid.UUID
+			u, err = uuid.Parse(t)
+			pu.UUID = u
+		}
+	case string:
+		*pu, err = NewPrefixUUID(t)
+	default:
+		return fmt.Errorf("types: can't scan value of unknown type %v into a PrefixUUID", value)
 	}
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Value implements the driver.Valuer interface.

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -95,6 +95,11 @@ func TestScan(t *testing.T) {
 	assertEquals(t, pu.Prefix, "pik_")
 	assertEquals(t, pu.UUID.String(), "6740b44e-13b9-475d-af06-979627e0e0d6")
 
+	err = pu.Scan("pik_6740b44e-13b9-475d-af06-979627e0e0d6")
+	assertNotError(t, err, "scanning string")
+	assertEquals(t, pu.Prefix, "pik_")
+	assertEquals(t, pu.UUID.String(), "6740b44e-13b9-475d-af06-979627e0e0d6")
+
 	err = pu.Scan([]byte("6740b44e-13b9-475d-af06-979627e0e0d6"))
 	assertNotError(t, err, "scanning byte array")
 	assertEquals(t, pu.Prefix, "")
@@ -106,5 +111,5 @@ func TestScan(t *testing.T) {
 
 	err = pu.Scan(7)
 	assertError(t, err, "scanning a number")
-	assertEquals(t, err.Error(), "types: can't scan value 7 into a PrefixUUID")
+	assertEquals(t, err.Error(), "types: can't scan value of unknown type 7 into a PrefixUUID")
 }


### PR DESCRIPTION
So you can get a prefix back from the database with a UUID by concatenating it
to the return value:

```
SELECT 'job_' || id FROM queued_jobs ...
```

However, github.com/lib/pq returns this value as a string, not a byte array.

Adds additional code to parse strings returned by lib/pq, as well as
to handle "longer" byte strings - for example, if you have a 36-byte
array where you use a whole byte to represent each character of
'cbd9f7a5-9707-4316-8825-036d9fd32bb3', instead of packing it into a 16 byte
array. Adds another test that we parse this the correct way.